### PR TITLE
Cleans up environment variables.

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,8 +36,9 @@ Depending on the speed of your platform, it may take a bit for the containers to
 
 Note that if you are using Docker Toolbox for Mac, you will need to find the IP address of your Docker Machine (try `docker-machine ls`), and use that IP address anywhere you see `localhost` in the following instructions.  
 
-* Visit http://localhost:8080/rest and see the Fedora REST API web page
+* Visit http://localhost:8080/fcrepo/rest and see the Fedora REST API web page
 * Visit http://localhost:9102/jsonld/ and see a JSON LD representation of the root Fedora container.
+* `curl -i http://localhost/fcrepo/rest` and see a response from API-X
 
 Once you can verify that the environment is up and working, move on to some of the sample [API-X exercises](apix-exercises.md).
 

--- a/acrepo/LATEST/Dockerfile
+++ b/acrepo/LATEST/Dockerfile
@@ -10,8 +10,10 @@ ENV JAVA_DEBUG_PORT ${DEBUG_PORT}
 EXPOSE ${DEBUG_PORT}
 EXPOSE 9102
 
-# The port that the Fedora repository is running on (in a separate container)
+# The host and port that the Fedora repository is running on (in a separate container)
+ENV FCREPO_HOST fcrepo
 ENV FCREPO_PORT 8080
+ENV FCREPO_CONTEXT_PATH /fcrepo
 
 # Allow the string "acrepo" to be recognized by Karaf as the Amherst feature repository
 

--- a/acrepo/LATEST/entrypoint.sh
+++ b/acrepo/LATEST/entrypoint.sh
@@ -8,10 +8,10 @@ sed -e "s:^org.ops4j.pax.url.mvn.localRepository=.*:org.ops4j.pax.url.mvn.localR
 
 # Update Amherst configurations
 
-# Change "fcrepo.baseUrl=localhost:8080/fcrepo/rest" to "fcrepo.baseUrl=fcrepo:${FCREPO_PORT}/rest"
+# Change "fcrepo.baseUrl=localhost:8080/fcrepo/rest" to "fcrepo.baseUrl=fcrepo:${FCREPO_PORT}/fcrepo/rest"
 for f in `ls etc/edu.amherst.*` ;
 do
-  sed -e "s:localhost\:8080/fcrepo/rest:fcrepo\:${FCREPO_PORT}/rest:" -i $f
+  sed -e "s:localhost\:8080/fcrepo/rest:fcrepo\:${FCREPO_PORT}${FCREPO_CONTEXT_PATH}/rest:" -i $f
 done
 
 # localhost:8080/fits to 0.0.0.0:8080/fits

--- a/apix/0.0.1/Dockerfile
+++ b/apix/0.0.1/Dockerfile
@@ -13,7 +13,9 @@ ENV APIX_VERSION 0.0.1-SNAPSHOT
 
 # The Fedora repository base URI
 ENV FCREPO_HOST=fcrepo
-ENV FCREPO_BASEURI=http://${FCREPO_HOST}:8080/rest
+ENV FCREPO_PORT=8080
+ENV FCREPO_CONTEXT_PATH=/fcrepo
+ENV FCREPO_BASEURI=http://${FCREPO_HOST}:${FCREPO_PORT}${FCREPO_CONTEXT_PATH}/rest
 
 # The Fuseki triplestore base URI
 ENV FUSEKI_HOST=fuseki
@@ -21,9 +23,11 @@ ENV FUSEKI_PORT=3030
 ENV FUSEKI_BASEURI=http://${FUSEKI_HOST}:${FUSEKI_PORT}
 
 # API-X base URI
-ENV APIX_HOST=0.0.0.0
+ENV APIX_HOST=localhost
 ENV APIX_PORT=80
-ENV APIX_BASEURI=http://${APIX_HOST}:${APIX_PORT}/rest
+ENV APIX_INTERCEPT_PATH=fcrepo/rest
+ENV APIX_BASEURI=http://${APIX_HOST}:${APIX_PORT}/${APIX_INTERCEPT_PATH}
+EXPOSE ${APIX_PORT}
 
 # Allow the string "apix" to be recognized by Karaf as the Fedora API-X feature repository
 

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -11,18 +11,13 @@ services:
   fcrepo:
     image: emetsger/apix-fcrepo:4.6.0
     container_name: fcrepo
-    environment:
-      - CONTEXT_PATH=/fcrepo
     ports:
+      - "5006:5006"
       - "8080:8080"
 
   acrepo:
     image: emetsger/apix-acrepo:latest
     container_name: acrepo
-    environment:
-      - DEBUG_PORT=5008
-      - FCREPO_HOST=fcrepo
-      - FCREPO_PORT=8080
     ports:
       - "5008:5008"
       - "9102:9102"
@@ -32,13 +27,11 @@ services:
   apix:
     image: emetsger/apix-core:latest
     container_name: apix
-    environment:
-      - DEBUG_PORT=5009
-      - FCREPO_HOST=fcrepo
-      - APIX_INTERCEPT_PATH=/fcrepo/rest
     ports:
       - "5009:5009"
       - "80:80"
       - "8081:8081"
     depends_on:
       - fcrepo
+    volumes:
+      - ~/.m2/repository:/build/repository

--- a/fcrepo/4.6.0/Dockerfile
+++ b/fcrepo/4.6.0/Dockerfile
@@ -1,9 +1,11 @@
-FROM emetsger/apix-build:latest 
+FROM emetsger/apix-build:latest
 
 ENV FCREPO_VERSION 4.6.0
 ENV FCREPO_RUNTIME /opt/fcrepo/${FCREPO_VERSION}
 ENV FCREPO_PORT    8080
+ENV FCREPO_CONTEXT_PATH /fcrepo
 ENV DEBUG_PORT     5006
+
 
 EXPOSE ${FCREPO_PORT}
 EXPOSE ${DEBUG_PORT}

--- a/fcrepo/4.6.0/entrypoint.sh
+++ b/fcrepo/4.6.0/entrypoint.sh
@@ -6,12 +6,12 @@ then
          -Dfcrepo.home=${FCREPO_RUNTIME}                             \
          -jar /tmp/fcrepo-webapp-${FCREPO_VERSION}-jetty-console.jar \
          --port ${FCREPO_PORT}                                       \
-         --contextPath ${CONTEXT_PATH}                               \
+         --contextPath ${FCREPO_CONTEXT_PATH}                        \
          --headless 2>&1
 else
     java -Dfcrepo.home=${FCREPO_RUNTIME}                             \
          -jar /tmp/fcrepo-webapp-${FCREPO_VERSION}-jetty-console.jar \
          --port ${FCREPO_PORT}                                       \
-         --contextPath ${CONTEXT_PATH}                               \
+         --contextPath ${FCREPO_CONTEXT_PATH}                        \
          --headless 2>&1
 fi


### PR DESCRIPTION
- Each container has explictly defined defaults.  Should work on all platforms except for docker-machine.

After application, you should be able to:
1) build the containers
2) docker-compose up -d
3) curl -iI http://localhost:8080/fcrepo/rest
4) curl -iI http://localhost:80/fcrepo/rest
5) curl -iI http://localhost:9102/jsonld