### PR TITLE
Documentation updates.

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,11 @@ To bring up this environment, you need to:
 1. Install Docker and verify the installation (above)
 2. Clone this repository
 3. `cd` into the repository directory
-4. Invoke `docker-compose up -d`
+4. **`docker-machine` users only:** set the `APIX_HOST` and `APIX_BASEURI` environment variable.  *Substitute the name of your docker machine for the `default` machine if necessary*:
+    * `docker-machine ip default` (ensure the output is an IP address, and not an error message)
+    * <code>echo "APIX_HOST=&#x60;docker-machine ip default&#x60;" > apix.env</code>
+    * <code>echo "APIX_BASEURI=http://&#x60;docker-machine ip default&#x60;/fcrepo/rest" >> apix.env</code>
+5. Invoke `docker-compose up -d`
 
 Depending on the speed of your platform, it may take a bit for the containers to download and to start.  Keep that in mind when you are verifying that the environment started up.  The containers should only be downloaded once.  Subsequent invocation of `docker-compose` should be faster, since the images will not need to be downloaded.
 
@@ -38,7 +42,7 @@ Note that if you are using Docker Toolbox for Mac, you will need to find the IP 
 
 * Visit http://localhost:8080/fcrepo/rest and see the Fedora REST API web page
 * Visit http://localhost:9102/jsonld/ and see a JSON LD representation of the root Fedora container.
-* `curl -i http://localhost/fcrepo/rest` and see a response from API-X
+* `curl -i -I http://localhost/fcrepo/rest` and see a response from API-X
 
 Once you can verify that the environment is up and working, move on to some of the sample [API-X exercises](apix-exercises.md).
 
@@ -50,10 +54,19 @@ This repository provides Dockerfiles for the following images:
 A base image, built from Ubuntu 16.04 (for various reasons, but mainly because Karaf 4.0.6+ requires glibc, and cannot use musl), containing a Java 8 build environment with Maven.
 
 ## [fcrepo 4.6.0](fcrepo/4.6.0)
-Extends the base image, and provides a default-configured Fedora 4.6.0 runtime on port 8080.  Debugging the runtime is possible by supplying an environment variable named "DEBUG".
+Extends the _build_ image, and provides a default-configured Fedora 4.6.0 runtime.
 
 ## [karaf 4.0.6](karaf/4.0.6)
-Extends the base image, and provides a Karaf container running version 4.0.6.  Debugging the runtime is possible by supplying `debug` as an argument to `docker run`.
+Extends the _build_ image, and provides a Karaf container running version 4.0.6.  Provides a base image for containers that need a Karaf runtime.
+
+## [fuseki](fuseki/2.3.1)
+Provides a triplestore index, useful for demonstrating the contents of the Fedora repository.  Extends the _build_ image.
 
 ## [acrepo](acrepo/LATEST)
-Extends the _karaf_ image, and provides a Karaf container with the Amherst features already installed and running.
+Ad-hoc [repository services provided by Amherst College](https://gitlab.amherst.edu/acdc/repository-extension-services/).  Extends the _karaf_ image, and provides a Karaf container with the Amherst features already installed and running.
+
+## [apix](apix/0.0.1)
+The core API-X image.  Extends the _karaf_ image, and provides a Karaf container with API-X features already installed and running.
+
+## [indexing](indexing/0.0.1)
+Ancillary (i.e. not considered "core") API-X image that keeps the demonstration triplestore up-to-date.

--- a/acrepo/LATEST/README.md
+++ b/acrepo/LATEST/README.md
@@ -8,6 +8,21 @@ The acrepo image default debugging port is 5008.  Debugging is enabled by defaul
 
 If running on a `docker-machine`, remember to publish the ports to the [host](https://docs.docker.com/engine/reference/run/#/expose-incoming-ports).
 
+## Environment variables and default values
+
+* DEBUG_PORT=5008
+* JAVA_DEBUG_PORT=${DEBUG_PORT}
+* FCREPO_HOST=fcrepo
+* FCREPO_PORT=8080
+* FCREPO_CONTEXT_PATH=/fcrepo
+
+*N.B.:* If you want to change the remote debugging port, you will need to set the `JAVA_DEBUG_PORT` environment variable, _not_ `DEBUG_PORT`.
+
+## Exposed ports
+
+* ${DEBUG_PORT}/${JAVA_DEBUG_PORT}
+* 9102
+
 ## Example Usage
 
 By default this container does _not_ start a Karaf console, and will emit logs to stdout (viewable by `docker logs <container name>`).
@@ -43,11 +58,6 @@ It seems that backspace (or other keys) do not work when executing the client.  
 
 #### Mount your local Maven repository in a container
 
+Useful when you wish to expose unpublished Maven artifacts or Karaf features to the container.
+
 `$ docker run -ti -v ~/.m2/repository:/build/repository emetsger/apix-acrepo:latest`
-
-### Environment variables and default values
-
-* DEBUG_PORT=5008
-* JAVA_DEBUG_PORT=${DEBUG_PORT}
-
-*N.B.:* If you want to change the remote debugging port, you will need to set the `JAVA_DEBUG_PORT` environment variable, _not_ `DEBUG_PORT`.

--- a/apix.env
+++ b/apix.env
@@ -1,0 +1,1 @@
+# Empty file must be kept, otherwise docker-compose will complain

--- a/apix/0.0.1/Dockerfile
+++ b/apix/0.0.1/Dockerfile
@@ -4,7 +4,7 @@ MAINTAINER Elliot Metsger <emetsger@jhu.edu>
 LABEL description = "Provides a Karaf container configured with API-X features"
 
 # The port Karaf will listen on when debugging is enabled
-ENV DEBUG_PORT 5009
+ENV DEBUG_PORT 5011
 ENV JAVA_DEBUG_PORT ${DEBUG_PORT}
 EXPOSE ${DEBUG_PORT}
 
@@ -16,11 +16,6 @@ ENV FCREPO_HOST=fcrepo
 ENV FCREPO_PORT=8080
 ENV FCREPO_CONTEXT_PATH=/fcrepo
 ENV FCREPO_BASEURI=http://${FCREPO_HOST}:${FCREPO_PORT}${FCREPO_CONTEXT_PATH}/rest
-
-# The Fuseki triplestore base URI
-ENV FUSEKI_HOST=fuseki
-ENV FUSEKI_PORT=3030
-ENV FUSEKI_BASEURI=http://${FUSEKI_HOST}:${FUSEKI_PORT}/fcrepo-triple-index
 
 # API-X base URI
 ENV APIX_HOST=localhost

--- a/apix/0.0.1/README.md
+++ b/apix/0.0.1/README.md
@@ -1,0 +1,69 @@
+## apix Dockerfile
+
+This image inherits from the [karaf image](../../karaf/4.0.6), so its configuration and environment also hold for this image.  However, this image does have some modifications which facilitate the installation and execution of API-X core features.
+
+The string "apixrepo" is a short cut recognized as the API-X feature repository at `mvn:org.fcrepo.apix/fedora-api-x-karaf/${APIX_VERSION}/xml/features`.  Features from this repository are installed into this Karaf image at _image build time_.
+
+The apix image default debugging port is 5011.  Debugging is enabled by default, but the port will need to be mapped using the `-p` command line argument to `docker run`.
+
+If running on a `docker-machine`, remember to publish the ports to the [host](https://docs.docker.com/engine/reference/run/#/expose-incoming-ports).
+
+## Environment variables and default values
+
+* DEBUG_PORT=5011
+* JAVA_DEBUG_PORT=${DEBUG_PORT}
+* FCREPO_HOST=fcrepo
+* FCREPO_PORT=8080
+* FCREPO_CONTEXT_PATH=/fcrepo
+* FCREPO_BASEURI=http://${FCREPO_HOST}:${FCREPO_PORT}${FCREPO_CONTEXT_PATH}/rest
+* APIX_VERSION=0.0.1-SNAPSHOT
+* APIX_HOST=localhost
+* APIX_PORT=80
+* APIX_INTERCEPT_PATH=fcrepo/rest
+* APIX_BASEURI=http://${APIX_HOST}:${APIX_PORT}/${APIX_INTERCEPT_PATH}
+
+*N.B.:* If you want to change the remote debugging port, you will need to set the `JAVA_DEBUG_PORT` environment variable, _not_ `DEBUG_PORT`.
+
+## Exposed ports
+
+* ${DEBUG_PORT}/${JAVA_DEBUG_PORT}
+* ${APIX_PORT}
+
+## Example Usage
+
+By default this container does _not_ start a Karaf console, and will emit logs to stdout (viewable by `docker logs <container name>`).  By default, a debugger runs on port 5009.
+
+#### Starting a container in the background
+
+No logs emitted to console:
+`$ docker run -d emetsger/apix-core`
+
+#### Starting a container in the foreground
+
+Logs emitted to console, allows CTRL-C to stop the container:
+`$ docker run -ti emetsger/apix-core`
+
+#### Start a container for debugging purposes
+
+Debugger can then be attached to port 5011, logs emitted to console, allows CTRL-C to stop container:
+`$ docker run -p "5011:5011" emetsger/apix-core debug`
+
+To use a different debugging port (in this example 4000):
+
+`$ docker run -ti -e JAVA_DEBUG_PORT=4000 -p "4000:4000" emetsger/apix-core debug`
+
+#### View container console log
+
+`$ docker logs <container name>`
+
+#### Obtain a Karaf console in a running container
+
+`$ docker exec -ti <container name> bin/client`
+
+It seems that backspace (or other keys) do not work when executing the client.  I am not sure why this is.
+
+#### Mount your local Maven repository in a container
+
+Useful when you wish to expose unpublished Maven artifacts or Karaf features to the container.
+
+`$ docker run -ti -v ~/.m2/repository:/build/repository emetsger/apix-core:latest`

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -12,12 +12,12 @@ services:
     image: emetsger/apix-fcrepo:4.6.0
     container_name: fcrepo
     ports:
-      - "5006:5006"
       - "8080:8080"
 
   indexing:
     image: emetsger/apix-indexing:latest
     container_name: indexing
+    env_file: apix.env
     ports:
       - "9090:9090"
     depends_on:
@@ -30,7 +30,6 @@ services:
     image: emetsger/apix-acrepo:latest
     container_name: acrepo
     ports:
-      - "5008:5008"
       - "9102:9102"
     depends_on:
       - fcrepo
@@ -38,8 +37,8 @@ services:
   apix:
     image: emetsger/apix-core:latest
     container_name: apix
+    env_file: apix.env
     ports:
-      - "5009:5009"
       - "80:80"
       - "8081:8081"
     depends_on:

--- a/fcrepo/4.6.0/README.md
+++ b/fcrepo/4.6.0/README.md
@@ -12,6 +12,7 @@ If running on a `docker-machine`, remember to publish the ports to the [host](ht
 * FCREPO_RUNTIME=/opt/fcrepo/4.0.6
 * FCREPO_PORT=8080
 * DEBUG_PORT=5006
+* FCREPO_CONTEXT_PATH=/fcrepo
 
 ## Exposed ports
 

--- a/fuseki/2.3.1/Dockerfile
+++ b/fuseki/2.3.1/Dockerfile
@@ -10,6 +10,9 @@ ENV FUSEKI_DEFAULT_DATASET /fcrepo-triple-index
 
 ENV DEBUG_PORT 5009
 
+EXPOSE 3030
+EXPOSE ${DEBUG_PORT}
+
 RUN export FUSEKI_DIST=apache-jena-fuseki-${FUSEKI_VERSION}.tar.gz       && \
     mkdir -p ${APPS}                                                     && \
     curl -L http://archive.apache.org/dist/jena/binaries/${FUSEKI_DIST}     \

--- a/fuseki/2.3.1/README.md
+++ b/fuseki/2.3.1/README.md
@@ -15,7 +15,8 @@ This image provides a Fuseki runtime.
 
 ## Exposed ports
 
-None.
+* 3030
+* ${DEBUG_PORT}
 
 ## entrypoint
 

--- a/indexing/0.0.1/README.md
+++ b/indexing/0.0.1/README.md
@@ -1,0 +1,72 @@
+## indexing Dockerfile
+
+This image inherits from the [karaf image](../../karaf/4.0.6), so its configuration and environment also hold for this image.  However, this image does have some modifications which facilitate the installation and execution of API-X indexing-related features.
+
+The indexing image default debugging port is 5010.  Debugging is enabled by default, but the port will need to be mapped using the `-p` command line argument to `docker run`.
+
+If running on a `docker-machine`, remember to publish the ports to the [host](https://docs.docker.com/engine/reference/run/#/expose-incoming-ports).
+
+## Environment variables and default values
+
+* DEBUG_PORT=5010
+* JAVA_DEBUG_PORT=${DEBUG_PORT}
+* FCREPO_CAMEL_VERSION=4.6.0
+* FCREPO_HOST=fcrepo
+* FCREPO_PORT=8080
+* FCREPO_CONTEXT_PATH=/fcrepo
+* FCREPO_BASEURI=http://${FCREPO_HOST}:${FCREPO_PORT}${FCREPO_CONTEXT_PATH}/rest
+* FUSEKI_HOST=fuseki
+* FUSEKI_PORT=3030
+* FUSEKI_BASEURI=http://${FUSEKI_HOST}:${FUSEKI_PORT}/fcrepo-triple-index
+* APIX_VERSION=0.0.1-SNAPSHOT
+* APIX_HOST=apix
+* APIX_PORT=80
+* APIX_INTERCEPT_PATH=fcrepo/rest
+* APIX_BASEURI=http://${APIX_HOST}:${APIX_PORT}/${APIX_INTERCEPT_PATH}
+* APIX_REINDEXING_SERVICE_URI=http://0.0.0.0:9090/reindexing
+
+*N.B.:* If you want to change the remote debugging port, you will need to set the `JAVA_DEBUG_PORT` environment variable, _not_ `DEBUG_PORT`.
+
+## Exposed ports
+
+* ${DEBUG_PORT}/${JAVA_DEBUG_PORT}
+* 9090
+
+## Example Usage
+
+By default this container does _not_ start a Karaf console, and will emit logs to stdout (viewable by `docker logs <container name>`).  By default, a debugger runs on port 5009.
+
+#### Starting a container in the background
+
+No logs emitted to console:
+`$ docker run -d emetsger/apix-indexing`
+
+#### Starting a container in the foreground
+
+Logs emitted to console, allows CTRL-C to stop the container:
+`$ docker run -ti emetsger/apix-indexing`
+
+#### Start a container for debugging purposes
+
+Debugger can then be attached to port 5010, logs emitted to console, allows CTRL-C to stop container:
+`$ docker run -p "5010:5010" emetsger/apix-indexing debug`
+
+To use a different debugging port (in this example 4000):
+
+`$ docker run -ti -e JAVA_DEBUG_PORT=4000 -p "4000:4000" emetsger/apix-indexing debug`
+
+#### View container console log
+
+`$ docker logs <container name>`
+
+#### Obtain a Karaf console in a running container
+
+`$ docker exec -ti <container name> bin/client`
+
+It seems that backspace (or other keys) do not work when executing the client.  I am not sure why this is.
+
+#### Mount your local Maven repository in a container
+
+Useful when you wish to expose unpublished Maven artifacts or Karaf features to the container.
+
+`$ docker run -ti -v ~/.m2/repository:/build/repository emetsger/apix-indexing:latest`


### PR DESCRIPTION
- Adds READMEs for the apix and indexing containers, and updates the repository-level README with high-level descriptions
- Updates docker-compose for docker-machine users, includes README update
- Removes extraneous port mappings from docker-compose (if people need to debug containers they can add the port mappings back in)
- Removes extraneous Fuseki-related env variables from apix image (it doesn't contact Fuseki at all, the indexing container does that now)