### PR TITLE
Tweak docker hostnames and links

### DIFF
--- a/acrepo/LATEST/Dockerfile
+++ b/acrepo/LATEST/Dockerfile
@@ -11,8 +11,8 @@ EXPOSE ${DEBUG_PORT}
 EXPOSE 9102
 
 # The host and port that the Fedora repository is running on (in a separate container)
-ENV FCREPO_HOST fcrepo
-ENV FCREPO_PORT 8080
+ENV FCREPO_HOST localhost
+ENV FCREPO_PORT 80
 ENV FCREPO_CONTEXT_PATH /fcrepo
 
 # Allow the string "acrepo" to be recognized by Karaf as the Amherst feature repository

--- a/acrepo/LATEST/entrypoint.sh
+++ b/acrepo/LATEST/entrypoint.sh
@@ -11,13 +11,13 @@ sed -e "s:^org.ops4j.pax.url.mvn.localRepository=.*:org.ops4j.pax.url.mvn.localR
 # Change "fcrepo.baseUrl=localhost:8080/fcrepo/rest" to "fcrepo.baseUrl=fcrepo:${FCREPO_PORT}/fcrepo/rest"
 for f in `ls etc/edu.amherst.*` ;
 do
-  sed -e "s:localhost\:8080/fcrepo/rest:fcrepo\:${FCREPO_PORT}${FCREPO_CONTEXT_PATH}/rest:" -i $f
+  sed -e "s:localhost\:8080/fcrepo/rest:${FCREPO_HOST}\:${FCREPO_PORT}${FCREPO_CONTEXT_PATH}/rest:" -i $f
 done
 
 # localhost:8080/fits to 0.0.0.0:8080/fits
 for f in `ls etc/edu.amherst.*` ;
 do
-    sed -e "s:localhost\:8080/fits:0\.0\.0\.0\:8080/fits:" -i $f
+    sed -e "s:localhost\:8080/fits:fits\:8080/fits:" -i $f
 done
 
 # Change "rest.host=localhost" to "rest.host=0.0.0.0"
@@ -31,6 +31,8 @@ for f in `ls etc/edu.amherst.*` ;
 do
     sed -e "s:localhost\:61616:fcrepo\:61616:" -i $f
 done
+
+echo "#empty" > /etc/hosts
 
 # Execute `bin/karaf` with any arguments suppled by CMD
 exec bin/karaf "$@"

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -31,8 +31,15 @@ services:
     container_name: acrepo
     ports:
       - "9102:9102"
+      - "9103:9103"
+      - "9104:9104"
+      - "9105:9105"
+      - "9106:9106"
+      - "9107:9107"
     depends_on:
       - fcrepo
+    links:
+      - apix:localhost
 
   apix:
     image: emetsger/apix-core:latest


### PR DESCRIPTION
This deals with the fact that the hostname for apix (or Fedora) should
ideally be resolvable both inside and outside docker containers, and also opens up
some additional acrepo ports