### PR TITLE
Use smaller base images

### DIFF
--- a/acrepo/LATEST/Dockerfile
+++ b/acrepo/LATEST/Dockerfile
@@ -1,9 +1,9 @@
-FROM fcrepoapix/apix-karaf:4.0.6
+FROM fcrepoapix/apix-karaf:4.0.7
 
 MAINTAINER Elliot Metsger <emetsger@jhu.edu>
 LABEL description = "Provides a Karaf container configured with Amherst features"
 # Needed for -image
-RUN apt-get update && apt-get -y install imagemagick
+RUN apt-get update && apt-get -y install imagemagick && rm -rf /var/lib/apt/lists/* && apt-get purge -y
 
 # The port acrepo Karaf will listen on when debugging is enabled
 

--- a/apix/0.0.1/Dockerfile
+++ b/apix/0.0.1/Dockerfile
@@ -1,4 +1,4 @@
-FROM fcrepoapix/apix-karaf:4.0.6
+FROM fcrepoapix/apix-karaf:4.0.7
 
 MAINTAINER Elliot Metsger <emetsger@jhu.edu>
 LABEL description = "Provides a Karaf container configured with API-X features"

--- a/fuseki/2.3.1/Dockerfile
+++ b/fuseki/2.3.1/Dockerfile
@@ -1,4 +1,4 @@
-FROM fcrepoapix/apix-build:latest
+FROM openjdk:8-jre-alpine
 
 ENV APPS                   /opt
 ENV SHARED                 /shared

--- a/indexing/0.0.1/Dockerfile
+++ b/indexing/0.0.1/Dockerfile
@@ -1,4 +1,4 @@
-FROM fcrepoapix/apix-karaf:4.0.6
+FROM fcrepoapix/apix-karaf:4.0.7
 
 MAINTAINER Elliot Metsger <emetsger@jhu.edu>
 LABEL description = "Provides a Karaf container configured with indexing features"

--- a/karaf/4.0.7/Dockerfile
+++ b/karaf/4.0.7/Dockerfile
@@ -1,0 +1,56 @@
+FROM openjdk:8-jre
+
+MAINTAINER Elliot Metsger <emetsger@jhu.edu>
+LABEL description = "Provides a Karaf container configured with a local Maven repository at ${MAVEN_REPO}"
+
+# Location of the Karaf installation in the docker container
+ENV KARAF_RUNTIME /opt/karaf
+
+# The version of Karaf to download and install in the container
+ENV KARAF_VERSION 4.0.4
+
+ENV MAVEN_REPO /build/repository
+
+# The port Karaf will listen on when debugging is enabled.
+#
+# Karaf actually pays attention to the value of JAVA_DEBUG_PORT, but in order
+# to be consistent with the environment variable (DEBUG_PORT) documented and
+# presented in the build/Dockerfile, assign the value of DEBUG_PORT to
+# JAVA_DEBUG_PORT
+ENV DEBUG_PORT 5007
+ENV JAVA_DEBUG_PORT=${DEBUG_PORT}
+EXPOSE ${DEBUG_PORT}
+EXPOSE ${JAVA_DEBUG_PORT}
+
+# Download and install Karaf, then clean up.
+RUN export KARAF_DIST=apache-karaf-${KARAF_VERSION}.tar.gz                         && \
+    curl -SL "http://archive.apache.org/dist/karaf/${KARAF_VERSION}/${KARAF_DIST}"    \
+        > /tmp/${KARAF_DIST}                                                       && \
+    mkdir -p ${KARAF_RUNTIME}                                                      && \
+    cd ${KARAF_RUNTIME}                                                            && \
+    tar -xzf /tmp/${KARAF_DIST}                                                    && \
+    rm -rf /tmp/apache-karaf-${KARAF_VERSION}*
+
+WORKDIR ${KARAF_RUNTIME}/apache-karaf-${KARAF_VERSION}
+
+# Update the Karaf configuration so that the Maven repository under ${MAVEN_REPO}
+# is used by Karaf to discover features.
+RUN sed -e "s:^#org.ops4j.pax.url.mvn.localRepository=:org.ops4j.pax.url.mvn.localRepository=${MAVEN_REPO}:"     \
+        -i etc/org.ops4j.pax.url.mvn.cfg                                                                      && \
+    sed -e "s:^#\(org.ops4j.pax.url.mvn.defaultLocalRepoAsRemote=\)false:\1true:"                                \
+        -i etc/org.ops4j.pax.url.mvn.cfg
+
+# Start Karaf, run a simple command with the client (to verify that Karaf
+# started) then stop it.  This establishes some kind of state that enables
+# commands to be scripted on container initialization
+# See https://goo.gl/5VfWsn
+
+RUN bin/start                            && \
+    bin/client -r 10 -d 5 system:version && \
+    bin/stop
+
+# Launch Karaf...
+ENTRYPOINT [ "bin/karaf" ]
+
+# ...with arguments provided by CMD
+CMD [ "console" ]

--- a/karaf/4.0.7/README.md
+++ b/karaf/4.0.7/README.md
@@ -1,0 +1,59 @@
+## karaf 4.0.7 Dockerfile
+
+This image provides a Karaf 4.0.7 instance, configured to use a local Maven repository as a Karaf features repository location.  
+
+This allows a developer to optionally install Karaf features into their local Maven repository (i.e. without publishing the features to a repository somewhere on the web), mount the local Maven repository into this container, and ask Karaf to install features from the local Maven repository.
+
+Arguments provided to this image when creating containers are considered as arguments to `bin/karaf`.  The default argument is `console`, which will start Karaf and launch the interactive Karaf console.  If remote debugging is desired, provide the `debug` argument instead of `console`.  By default, a remote debug port will be available on port 5007.
+
+If running on a `docker-machine`, remember to publish the ports to the [host](https://docs.docker.com/engine/reference/run/#/expose-incoming-ports).
+
+## Environment variables and default values
+
+* KARAF_VERSION=4.0.7
+* KARAF_RUNTIME=/opt/karaf/${KARAF_VERSION}
+* KARAF_DIST=apache-karaf-${KARAF_VERSION}
+* DEBUG_PORT=5007
+* JAVA_DEBUG_PORT=${DEBUG_PORT}
+
+*N.B.:* If you want to change the remote debugging port, you will need to set the `JAVA_DEBUG_PORT` environment variable, _not_ `DEBUG_PORT`.
+
+## Exposed ports
+
+* ${DEBUG_PORT}
+* ${JAVA_DEBUG_PORT}
+
+## Example Usage
+
+#### Starting
+
+Launches a Karaf interactive console, which may be exited using CTRL-D.
+
+`$ docker run -ti emetsger/apix-karaf:4.0.7`
+
+#### Debugging
+
+Launches an interactive Karaf console with Java remote debugging enabled on the default `${JAVA_DEBUG_PORT}` (in this example port 5007):
+
+`$ docker run -ti -p "5007:5007" emetsger/apix-karaf:4.0.7 debug`
+
+To use a different debugging port (in this example 4000):
+
+`$ docker run -ti -e JAVA_DEBUG_PORT=4000 -p "4000:4000" emetsger/apix-karaf:4.0.7 debug`
+
+#### Display logs
+
+Karaf logs are not echoed out to the console.  There are a couple ways to see them:
+
+1.  Launch an interactive console and use the Karaf command `log:display`
+2.  Obtain a shell in a running container and `tail -f data/log/karaf.log`
+
+#### Obtain a shell
+
+To obtain a shell in a running container, first [start the container](#starting), and then in another shell window run:
+
+`$ docker exec -ti <container name> /bin/bash`
+
+Alternately, to simply shell into a non-existent container, override the entrypoint:
+
+`$ docker run -ti --entrypoint=/bin/bash emetsger/apix-karaf:4.0.7`


### PR DESCRIPTION
Base off non-alpine openjdk base images; smallest alpine images
are incompatible with Karaf, due to
https://github.com/fusesource/jansi/issues/58

Also provide Karaf 4.0.7