### PR TITLE
Add default config for fcrepo-api-x-registry in indexing image

### DIFF
--- a/indexing/0.3.0-SNAPSHOT/cfg/org.fcrepo.apix.registry.http.cfg
+++ b/indexing/0.3.0-SNAPSHOT/cfg/org.fcrepo.apix.registry.http.cfg
@@ -1,0 +1,1 @@
+timeout.socket.ms = ${env:HTTP_REGISTRY_TIMEOUT_MS:-10000}


### PR DESCRIPTION
This allows configuration to be consistent with the apix image, and fixes
an issue of an NPE upon startup of the indexing image

Resolves #43 