### PR TITLE
Clean and remove redundant files from images

### DIFF
--- a/acrepo/1.1.0/Dockerfile
+++ b/acrepo/1.1.0/Dockerfile
@@ -1,4 +1,4 @@
-FROM fcrepoapix/apix-karaf-camel:4.0.9@sha256:bbea3acdab13f6f6a321b1b9e08e2ce1af4e741f2ca31b36014f087f0fefa1a6
+FROM fcrepoapix/apix-karaf-camel:4.0.9@sha256:130e48a21aaa0ec3c6739dddc69d70dde9a33f5a348bc84121d049367ee05e93
 
 MAINTAINER Elliot Metsger <emetsger@jhu.edu>
 LABEL description = "Provides a Karaf container configured with Amherst features"
@@ -26,7 +26,8 @@ RUN apk --no-cache add --update imagemagick  && \
     bin/client -r 10 -d 5  "feature:install camel fcrepo-camel acrepo-exts-ore acrepo-exts-image acrepo-exts-pcdm acrepo-exts-fits acrepo-exts-serialize-xml" && \
     /bin/sleep 15 && \
     bin/stop && \
-    rm -rf instances/*
+    rm -rf instances/* && \
+    rm -rf /build/repository/*
 
 COPY entrypoint.sh /entrypoint.sh
 

--- a/apix/0.3.0-SNAPSHOT/Dockerfile
+++ b/apix/0.3.0-SNAPSHOT/Dockerfile
@@ -1,4 +1,4 @@
-FROM fcrepoapix/apix-karaf-camel:4.0.9@sha256:bbea3acdab13f6f6a321b1b9e08e2ce1af4e741f2ca31b36014f087f0fefa1a6
+FROM fcrepoapix/apix-karaf-camel:4.0.9@sha256:130e48a21aaa0ec3c6739dddc69d70dde9a33f5a348bc84121d049367ee05e93
 
 MAINTAINER Elliot Metsger <emetsger@jhu.edu>
 LABEL description = "Provides a Karaf container configured with API-X features"
@@ -34,7 +34,8 @@ RUN export REGISTRY_ONTOLOGY_CREATE=false  && \
     bin/client -r 10 -d 5 "feature:repo-add  mvn:org.fcrepo.apix/fcrepo-api-x-karaf/${APIX_VERSION}/xml/features" && \
     bin/client -r 10 -d 5 "feature:install fcrepo-api-x" && \
     bin/stop && \
-    rm -rf instances/*
+    rm -rf instances/* && \
+    rm -rf /build/repository/*
 
 COPY cfg/* etc/
 

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -52,7 +52,7 @@ services:
       - apix:localhost
 
   apix:
-    image: fcrepoapix/apix-core:0.3.0
+    image: fcrepoapix/apix-core:0.3.0-SNAPSHOT
     build: apix/0.3.0-SNAPSHOT
     container_name: apix
     env_file: .env

--- a/fcrepo/4.7.1-1/Dockerfile
+++ b/fcrepo/4.7.1-1/Dockerfile
@@ -48,7 +48,9 @@ RUN echo "http://dl-3.alpinelinux.org/alpine/v3.5/main/" > /etc/apk/repositories
     cd ..                                                                                && \
     rm -rf fcrepo4                                                                       && \
     rm -rf /build/repository                                                             && \
-    rm -rf ~/.m2
+    rm -rf ~/.m2                                                                         && \
+    rm -rf /root/.victims*                                                               && \
+    apk --no-cache del maven git
 
 COPY entrypoint.sh /
 

--- a/indexing/0.3.0-SNAPSHOT/Dockerfile
+++ b/indexing/0.3.0-SNAPSHOT/Dockerfile
@@ -1,4 +1,4 @@
-FROM fcrepoapix/apix-karaf-camel:4.0.9@sha256:bbea3acdab13f6f6a321b1b9e08e2ce1af4e741f2ca31b36014f087f0fefa1a6
+FROM fcrepoapix/apix-karaf-camel:4.0.9@sha256:130e48a21aaa0ec3c6739dddc69d70dde9a33f5a348bc84121d049367ee05e93
 
 MAINTAINER Elliot Metsger <emetsger@jhu.edu>
 LABEL description = "Provides a Karaf container configured with indexing features"
@@ -22,7 +22,8 @@ RUN bin/start && \
     bin/client -r 10 -d 5  "feature:install fcrepo-api-x-indexing" && \
     bin/client -r 10 -d 5  "feature:install fcrepo-indexing-triplestore" && \
     bin/stop && \
-    rm -rf instances/*
+    rm -rf instances/* && \
+    rm -rf /build/repository/*
 
 # Copy Karaf feature configuration files into the image
 COPY cfg/* etc/

--- a/karaf/4.0.9-camel/Dockerfile
+++ b/karaf/4.0.9-camel/Dockerfile
@@ -14,4 +14,5 @@ RUN bin/start && \
     bin/client -r 10 -d 5  "feature:install camel-http4" && \
     bin/client -r 10 -d 5  "feature:install camel-jetty" && \
     bin/stop && \
-    rm -rf instances/*
+    rm -rf instances/* && \
+    rm -rf /build/repository/*


### PR DESCRIPTION
- Remove redundant jars from maven repo in Karaf images
- Remove packages from fcrepo build when finished
- Fix API-X version to 0.3.0-SNAPSHOT