### PR TITLE
Update Karaf to Camel 2.19.x, Activemq 5.15.x

### DIFF
--- a/apix/0.3.0-SNAPSHOT/Dockerfile
+++ b/apix/0.3.0-SNAPSHOT/Dockerfile
@@ -1,4 +1,4 @@
-FROM fcrepoapix/apix-karaf-camel:4.0.9@sha256:130e48a21aaa0ec3c6739dddc69d70dde9a33f5a348bc84121d049367ee05e93
+FROM fcrepoapix/apix-karaf-camel:4.0.9-1@sha256:5f19f8266f2c44ec33e2d962312654e666a85bc6f31343b3fa94e376ff1707fa
 
 MAINTAINER Elliot Metsger <emetsger@jhu.edu>
 LABEL description = "Provides a Karaf container configured with API-X features"
@@ -21,7 +21,7 @@ EXPOSE ${APIX_PORT}
 EXPOSE ${DEBUG_PORT}
 
 # Temporary for local development; copy any Maven artifacts into `maven/` that you want the image build process to see (e.g. locally build features that have yet to be published)
-#ADD maven/ /build/repository/
+# ADD maven/ /build/repository/
 
 # Install all of the latest features found in the apixrepo features repository (typically these features will be SNAPSHOT versions) ...
 # ... but do not create registry containers or attept to index registry content, as the Fedora repository is not available at image build time

--- a/indexing/0.3.0-SNAPSHOT/Dockerfile
+++ b/indexing/0.3.0-SNAPSHOT/Dockerfile
@@ -1,4 +1,4 @@
-FROM fcrepoapix/apix-karaf-camel:4.0.9@sha256:130e48a21aaa0ec3c6739dddc69d70dde9a33f5a348bc84121d049367ee05e93
+FROM fcrepoapix/apix-karaf-camel:4.0.9-1@sha256:5f19f8266f2c44ec33e2d962312654e666a85bc6f31343b3fa94e376ff1707fa
 
 MAINTAINER Elliot Metsger <emetsger@jhu.edu>
 LABEL description = "Provides a Karaf container configured with indexing features"

--- a/karaf/4.0.9-camel-1/Dockerfile
+++ b/karaf/4.0.9-camel-1/Dockerfile
@@ -1,0 +1,18 @@
+FROM fcrepoapix/apix-karaf:4.0.9@sha256:d0a2910efaa3b97b508ca80225377ba2ce07a66078e61364d291b731f1bea1e8
+
+MAINTAINER Elliot Metsger <emetsger@jhu.edu>
+LABEL description = "Provides a Karaf container configured with Camel and Activemq pre-loaded"
+
+# Camel and Activemq versions
+ENV CAMEL_VERSION=2.19.2 \
+    ACTIVEMQ_VERSION=5.15.0 
+
+RUN bin/start && \
+    bin/client -r 10 -d 5  "feature:repo-add mvn:org.apache.camel.karaf/apache-camel/${CAMEL_VERSION}/xml/features" && \
+    bin/client -r 10 -d 5  "feature:repo-add mvn:org.apache.activemq/activemq-karaf/${ACTIVEMQ_VERSION}/xml/features" && \
+    bin/client -r 10 -d 5  "feature:install activemq-camel" && \
+    bin/client -r 10 -d 5  "feature:install camel-http4" && \
+    bin/client -r 10 -d 5  "feature:install camel-jetty" && \
+    bin/stop && \
+    rm -rf instances/* && \
+    rm -rf /build/repository/*

--- a/karaf/4.0.9-camel-1/README.md
+++ b/karaf/4.0.9-camel-1/README.md
@@ -1,0 +1,7 @@
+## karaf 4.0.9 Dockerfile
+
+This image builds on the [Karaf 4.0.9 docker image](../4.0.9/README.md) by
+installing Camel and ActiveMQ features.  This is a mechanism that saves
+comsiderable space, as Camel and ActiveMQ are larged.  To the extent that
+images are built off this one, the space consumed by Camel and ActiveMQ will
+be shared between all images.

--- a/karaf/docker-compose.yml
+++ b/karaf/docker-compose.yml
@@ -8,5 +8,5 @@ services:
       build: 4.0.9
 
     karaf-camel:
-      image: fcrepoapix/apix-karaf-camel:4.0.9
-      build: 4.0.9-camel
+      image: fcrepoapix/apix-karaf-camel:4.0.9-1
+      build: 4.0.9-camel-1


### PR DESCRIPTION
Create new Karaf base images, and build apix images off that.  Leave
acrepo on old Camel due to jetty component incompatibilities.