### PR TITLE
Adds serialization camel route.

### DIFF
--- a/.env.toolbox
+++ b/.env.toolbox
@@ -1,0 +1,2 @@
+# Serialization Tool environement variable
+SERIALIZATION_INPUT_STREAM=broker:topic:no_fedora

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -70,7 +70,9 @@ services:
     image: fcrepoapix/fcrepo-toolbox:4.7.2-1
     build: toolbox/4.7.2-1
     container_name: toolbox
-    env_file: .env
+    env_file:
+      - .env
+      - .env.toolbox
     ports:
       - "${REINDEXING_PORT}:${REINDEXING_PORT}"
       - "${LDPATH_PORT}:${LDPATH_PORT}"

--- a/toolbox/4.7.2-1/Dockerfile
+++ b/toolbox/4.7.2-1/Dockerfile
@@ -10,7 +10,7 @@ ENV FCREPO_TOOLBOX_VERSION=4.7.2 \
 
 # Temporary for local development; copy any Maven artifacts into `maven/` that you want the image build process to see (e.g. locally build features that have yet to be published)
 #ADD maven/ /build/repository/
-RUN apk add --update --no-cache gettext && \ 
+RUN apk add --update --no-cache gettext tree nano && \
     bin/start && \
     bin/client -r 10 -d 5  "feature:repo-add mvn:org.fcrepo.camel/toolbox-features/${FCREPO_TOOLBOX_VERSION}/xml/features" && \
     bin/client -r 10 -d 5  "feature:repo-add mvn:org.fcrepo.apix/fcrepo-api-x-karaf/${APIX_VERSION}/xml/features" && \
@@ -21,6 +21,7 @@ RUN apk add --update --no-cache gettext && \
     bin/client -r 10 -d 5  "feature:install fcrepo-api-x-registry" && \
     bin/client -r 10 -d 5  "feature:install fcrepo-api-x-indexing" && \
     bin/client -r 10 -d 5  "feature:install fcrepo-reindexing" && \
+    bin/client -r 10 -d 5  "feature:install fcrepo-serialization" && \
     bin/stop && \
     rm -rf instances/* && \
     rm -rf /build/repository/* && \

--- a/toolbox/4.7.2-1/cfg/org.fcrepo.camel.serialization.cfg
+++ b/toolbox/4.7.2-1/cfg/org.fcrepo.camel.serialization.cfg
@@ -17,7 +17,7 @@ serialization.descriptions=/tmp/descriptions
 serialization.binaries=/tmp/binaries
 
 # The flag for whether or not to write binaries to disk.
-serialization.includeBinaries=true
+serialization.includeBinaries=false
 
 # The format the metadata files will be written in.
 serialization.mimeType=text/turtle

--- a/toolbox/4.7.2-1/cfg/org.fcrepo.camel.serialization.cfg
+++ b/toolbox/4.7.2-1/cfg/org.fcrepo.camel.serialization.cfg
@@ -1,0 +1,31 @@
+# In the event of failure, the maximum number of times a redelivery will be attempted.
+error.maxRedeliveries=10
+
+# The JMS connection URI, used for connecting to a local or remote ActiveMQ broker.
+jms.brokerUrl=tcp://${env:FCREPO_HOST:-fcrepo}:61616
+
+# The camel URI for the incoming message stream.
+input.stream=${env:SERIALIZATION_INPUT_STREAM:-broker:queue:no_serialization}
+
+# The camel URI for re-serialization events
+serialization.stream=broker:queue:serialization
+
+# The directory to store the metadata files in.
+serialization.descriptions=/tmp/descriptions
+
+# The directory to store the binary files in, if writing them to disk.
+serialization.binaries=/tmp/binaries
+
+# The flag for whether or not to write binaries to disk.
+serialization.includeBinaries=true
+
+# The format the metadata files will be written in.
+serialization.mimeType=text/turtle
+
+# The file extension that will be used for the metadata files.
+serialization.extension=ttl
+
+# A comma-delimited list of URIs to filter. That is, any Fedora resource that either
+# matches or is contained in one of the URIs listed will not be processed by the
+# fcrepo-serialization application.
+filter.containers=${env:PUBLIC_REPOSITORY_BASEURI:-http://localhost:8080/fcrepo/rest}/audit


### PR DESCRIPTION
Adds nano and tree to toolbox image.

These are some changes I'll probably need for Fedora Camp Texas.  

This might be enough for now. It would be lovely to get the routes to reload when the cfg file changes, but that might not happen before the camp.  In which case this PR is ready to go. 