### PR TITLE
Expose messaging ports and add listener

### DIFF
--- a/.env
+++ b/.env
@@ -10,6 +10,8 @@ PUBLIC_REPOSITORY_BASEURI=http://localhost/fcrepo/rest
 # to change anything here
 FCREPO_HOST=fcrepo
 FCREPO_PORT=8080
+FCREPO_JMS_PORT=61616
+FCREPO_STOMP_PORT=61613
 FCREPO_CONTEXT_PATH=/fcrepo
 FCREPO_BASEURI=http://fcrepo:8080/fcrepo/rest
 FCREPO_PROXYURI=http://fcrepo:8080/fcrepo

--- a/fcrepo/4.7.4-1/Dockerfile
+++ b/fcrepo/4.7.4-1/Dockerfile
@@ -29,7 +29,9 @@ RUN apk update && \
     echo "f58682cd322517718f0168e0038e874774507285 *${CATALINA_HOME}/webapps/fcrepo.war" \
         | sha1sum -c -  && \
     echo "org.apache.catalina.webresources.Cache.level = SEVERE" \
-      >> ${CATALINA_HOME}/conf/logging.properties
+      >> ${CATALINA_HOME}/conf/logging.properties && \
+    wget -O /usr/local/bin/fcr-listen https://github.com/birkland/fcr-listen/releases/download/0.0.1/fcr-listen-`uname -s`-`uname -m` && \
+    chmod +x /usr/local/bin/fcr-listen
 
 COPY entrypoint.sh /
 COPY conf/* ${CATALINA_HOME}/conf/

--- a/fcrepo/4.7.4-1/entrypoint.sh
+++ b/fcrepo/4.7.4-1/entrypoint.sh
@@ -35,6 +35,8 @@ OPTS="-Dfcrepo.log=${FCREPO_LOG_LEVEL}                                       \
       -Dfcrepo.object.directory=${FCREPO_OBJECT_DIRECTORY}                   \
       -Dfcrepo.activemq.configuration=${FCREPO_ACTIVEMQ_CONFIGURATION}       \
       -Dactivemq.broker.uri=${ACTIVEMQ_BROKER_URI}                           \
+      -Dfcrepo.dynamic.jms.port=${FCREPO_JMS_PORT}                           \
+      -Dfcrepo.dynamic.stomp.port=${FCREPO_STOMP_PORT}                       \
       -Dcom.arjuna.ats.arjuna.objectstore.objectStoreDir=${ARJUNA_OBJECTSTORE_DIRECTORY}"
 
 # handle debugging


### PR DESCRIPTION
Exposes (and makes configurable) openwire and STOMP ports for fcrepo.

Adds the fcr-listen application for displaying/debugging messages sent by
Fedora

See also: https://github.com/birkland/fcr-listen